### PR TITLE
Fix more broken links using baseurl annotation

### DIFF
--- a/docs/config-options/cloud-providers/vsphere/vsphere.md
+++ b/docs/config-options/cloud-providers/vsphere/vsphere.md
@@ -7,7 +7,7 @@ This section describes how to enable the vSphere cloud provider. You will need t
 
 The [vSphere Cloud Provider](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/) interacts with VMware infrastructure (vCenter or standalone ESXi server) to provision and manage storage for persistent volumes in a Kubernetes cluster.
 
-When provisioning Kubernetes using RKE CLI or using [RKE clusters]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/) in Rancher, the vSphere Cloud Provider can be enabled by configuring the `cloud_provider` directive in the cluster YAML file.
+When provisioning Kubernetes using RKE CLI or using [RKE clusters](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher) in Rancher, the vSphere Cloud Provider can be enabled by configuring the `cloud_provider` directive in the cluster YAML file.
 
 ### Related Links
 

--- a/docs/managing-clusters/managing-clusters.md
+++ b/docs/managing-clusters/managing-clusters.md
@@ -20,7 +20,7 @@ After you've made changes to add/remove nodes, run `rke up` with the updated `cl
 
 You can add/remove only worker nodes, by running `rke up --update-only`. This will ignore everything else in the `cluster.yml` except for any worker nodes.
 
-> **Note:** When using `--update-only`, other actions that do not specifically relate to nodes may be deployed or updated, for example [addons]({{< baseurl >}}/rke/latest/en/config-options/add-ons).
+> **Note:** When using `--update-only`, other actions that do not specifically relate to nodes may be deployed or updated, for example [addons](../config-options/add-ons/add-ons.md).
 
 ### Removing Kubernetes Components from Nodes
 


### PR DESCRIPTION
There were a couple more instance of the old `{{<baseurl>}}` notation from our old Hugo setup that didn't get picked up when testing with `yarn build`.