### PR TITLE
Add deprecation warning in the docs

### DIFF
--- a/docs/cert-mgmt/cert-mgmt.md
+++ b/docs/cert-mgmt/cert-mgmt.md
@@ -90,7 +90,7 @@ If the CA certificate needs to be rotated, you are required to rotate all the se
 
 Rotating the CA certificate will result in restarting other system pods, that will also use the new CA certificate. This includes:
 
-- Networking pods (canal, calico, flannel, and weave)
+- Networking pods (canal, calico and flannel)
 - Ingress Controller pods
 - KubeDNS pods
 

--- a/docs/config-options/add-ons/network-plugins/network-plugins.md
+++ b/docs/config-options/add-ons/network-plugins/network-plugins.md
@@ -159,7 +159,11 @@ kubectl -n kube-system get deploy calico-kube-controllers -o jsonpath='{.spec.te
 
 ## Weave
 
+:::caution
+
 Weave is deprecated in v1.27 and will be removed in v1.30
+
+:::
 
 ### Weave Network Plug-in Options
 

--- a/docs/config-options/add-ons/network-plugins/network-plugins.md
+++ b/docs/config-options/add-ons/network-plugins/network-plugins.md
@@ -158,6 +158,9 @@ kubectl -n kube-system get deploy calico-kube-controllers -o jsonpath='{.spec.te
 ```
 
 ## Weave
+
+Weave is deprecated in v1.27 and will be removed in v1.30
+
 ### Weave Network Plug-in Options
 
 ```yaml

--- a/docs/example-yamls/example-yamls.md
+++ b/docs/example-yamls/example-yamls.md
@@ -319,7 +319,7 @@ cloud_provider:
 # up on trying to get the job status after this timeout in seconds..
 addon_job_timeout: 30
 
-# Specify network plugin-in (canal, calico, flannel, weave, or none)
+# Specify network plugin-in (canal, calico, flannel or none)
 network:
   plugin: canal
   # Specify MTU

--- a/docs/os/os.md
+++ b/docs/os/os.md
@@ -31,7 +31,7 @@ Users added to the `docker` group are granted effective root permissions on the 
   - [Calico](https://docs.projectcalico.org/getting-started/kubernetes/requirements#kernel-dependencies)
   - [Flannel](https://github.com/flannel-io/flannel/tree/master/Documentation)
   - Canal (Combination Calico and Flannel)
-  - [Weave](https://www.weave.works/docs/net/latest/install/installing-weave/)
+  - [Weave](https://www.weave.works/docs/net/latest/install/installing-weave/) (Deprecated)
 
 :::note
 


### PR DESCRIPTION
Add deprecation warning when using Weave and remove weave from the examples.

Related issue: https://github.com/rancher/rke/issues/3338
Related JIRA: https://jira.suse.com/browse/SURE-6793