### PR TITLE
Update Nginx ingress config example docs

### DIFF
--- a/docs/config-options/add-ons/ingress-controllers/ingress-controllers.md
+++ b/docs/config-options/add-ons/ingress-controllers/ingress-controllers.md
@@ -129,7 +129,7 @@ By default, the nginx ingress controller is configured using `hostNetwork: true`
 </TabItem>
 </Tabs>
 
-Configure the nginx ingress controller using `hostPort` and override the default ports:
+Here's an example of how to configure the nginx ingress controller using `hostPort` and override the default ports:
 
 ```yaml
 ingress:
@@ -138,11 +138,11 @@ ingress:
   http_port: 9090
   https_port: 9443
   extra_args:
-    http-port: 8080
-    https-port: 8443
+    http-port: 3080
+    https-port: 3443
 ```
 
-Configure the nginx ingress controller using `hostNetwork`:
+Here's an example of how to configure the nginx ingress controller using `hostNetwork`:
 
 ```yaml
 ingress:
@@ -150,7 +150,7 @@ ingress:
   network_mode: hostNetwork
 ```
 
-Configure the nginx ingress controller with no network mode which will make it run on the overlay network (for example, if you want to expose the nginx ingress controller using a `LoadBalancer`) and override the default ports:
+Here's an example of how to configure the nginx ingress controller with no network mode which will make it run on the overlay network (for example, if you want to expose the nginx ingress controller using a `LoadBalancer`) and override the default ports:
 
 ```yaml
 ingress:


### PR DESCRIPTION
I'm updating the docs about Nginx ingress configuration to address some confusion reported by a customer. The docs don't make it entirely clear that the configuration snippets provided are simply examples of how configuration might look depending on your goals (as opposed to direct instructions on the exact configuration to use). The first example also has Nginx using custom ports 8080 and 8443, which are already used by the Nginx webhook internally. If users copy this config verbatim and do `rke up`, their ingress will be broken due to the port mapping conflict. I just changed the example ports to address this.

The default k8s Nginx webhook port that is causing the conflict is here: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml#L581
It's included in the deployment here: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/templates/controller-deployment.yaml#L132