### PR TITLE
Replace deprecated caution admonition

### DIFF
--- a/docs/config-options/add-ons/dns/dns.md
+++ b/docs/config-options/add-ons/dns/dns.md
@@ -257,7 +257,7 @@ dns:
 
 By removing the `ip_address` value, NodeLocal DNS will be removed from the cluster.
 
-:::caution
+:::warning
 
 When removing NodeLocal DNS, a disruption to DNS can be expected. The updated `/etc/resolv.conf` configuration will take effect only for pods that are started after removing NodeLocal DNS. In general pods using the default `dnsPolicy: ClusterFirst` will need to be re-deployed.
 

--- a/docs/config-options/add-ons/network-plugins/network-plugins.md
+++ b/docs/config-options/add-ons/network-plugins/network-plugins.md
@@ -9,7 +9,7 @@ RKE provides the following network plug-ins that are deployed as add-ons:
 - Canal
 - Weave
 
-:::caution
+:::warning
 
 After you launch the cluster, you cannot change your network provider. Therefore, choose which network provider you want to use carefully, as Kubernetes doesn’t allow switching between network providers. Once a cluster is created with a network provider, changing network providers would require you tear down the entire cluster and all its applications.
 
@@ -159,7 +159,7 @@ kubectl -n kube-system get deploy calico-kube-controllers -o jsonpath='{.spec.te
 
 ## Weave
 
-:::caution
+:::warning
 
 Weave is deprecated in v1.27 and will be removed in v1.30
 

--- a/docs/config-options/secrets-encryption/secrets-encryption.md
+++ b/docs/config-options/secrets-encryption/secrets-encryption.md
@@ -121,7 +121,7 @@ With managed configuration, RKE provides the user with a very simple way to enab
 
 With custom encryption configuration, RKE allows the user to provide their own configuration. Although RKE will help the user to deploy the configuration and rewrite the secrets if needed, it doesn't provide a configuration validation on user's behalf. It's the user responsibility to make sure their configuration is valid.
 
-:::caution
+:::warning
 
 Using invalid Encryption Provider Configuration could cause several issues with your cluster, ranging from crashing the Kubernetes API service, `kube-api`,  to completely losing access to encrypted data.
 


### PR DESCRIPTION
Per https://docusaurus.io/docs/migration/v3#admonition-warning, the `caution` admonition has been deprecated and replaced by the previously undocumented `:::warning` admonition`.