### PR TITLE
Updating vSphere/OpenStack Cloud Providers - rancher_kubernetes_engine_config

### DIFF
--- a/docs/config-options/cloud-providers/openstack/openstack.md
+++ b/docs/config-options/cloud-providers/openstack/openstack.md
@@ -2,7 +2,7 @@
 title: OpenStack Cloud Provider
 ---
 
-To enable the OpenStack cloud provider, besides setting the name as `openstack`, specific configuration options must be set as defined below. The OpenStack configuration options are grouped into different sections and they must be nested under the `rancher_kubernetes_engine_config` directive in the cluster config YAML file. For more information on the configuration file structure, please see the [Rancher RKE Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#config-file-structure-in-rancher).
+To enable the OpenStack cloud provider, besides setting the name as `openstack`, there are specific configuration options that must be set. The OpenStack configuration options are grouped into different sections provided in an example below.
 
 ```yaml
 cloud_provider:
@@ -23,6 +23,8 @@ cloud_provider:
       metadata:
         search-order: xxxxxxxxxxxxxx
 ```
+
+If you are enabling the OpenStack cloud provider in Rancher the configurations must be nested under the `rancher_kubernetes_engine_config` directive in the cluster config YAML file. See here for more information on the [Rancher configuration file structure](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#config-file-structure-in-rancher).
 
 ## Overriding the hostname
 

--- a/docs/config-options/cloud-providers/openstack/openstack.md
+++ b/docs/config-options/cloud-providers/openstack/openstack.md
@@ -2,7 +2,7 @@
 title: OpenStack Cloud Provider
 ---
 
-To enable the OpenStack cloud provider, besides setting the name as `openstack`, there are specific configuration options that must be set as defined below. The OpenStack configuration options are grouped into different sections and they must be nested under the `rancher_kubernetes_engine_config` directive in the cluster config YAML file. For more information on the configuration file structure please see the [Rancher RKE Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#config-file-structure-in-rancher).
+To enable the OpenStack cloud provider, besides setting the name as `openstack`, specific configuration options must be set as defined below. The OpenStack configuration options are grouped into different sections and they must be nested under the `rancher_kubernetes_engine_config` directive in the cluster config YAML file. For more information on the configuration file structure, please see the [Rancher RKE Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#config-file-structure-in-rancher).
 
 ```yaml
 cloud_provider:

--- a/docs/config-options/cloud-providers/openstack/openstack.md
+++ b/docs/config-options/cloud-providers/openstack/openstack.md
@@ -2,7 +2,7 @@
 title: OpenStack Cloud Provider
 ---
 
-To enable the OpenStack cloud provider, besides setting the name as `openstack`, there are specific configuration options that must be set. The OpenStack configuration options are grouped into different sections.
+To enable the OpenStack cloud provider, besides setting the name as `openstack`, there are specific configuration options that must be set as defined below. The OpenStack configuration options are grouped into different sections and they must be nested under the `rancher_kubernetes_engine_config` directive in the cluster config YAML file. For more information on the configuration file structure please see the [Rancher RKE Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#config-file-structure-in-rancher).
 
 ```yaml
 cloud_provider:

--- a/docs/config-options/cloud-providers/vsphere/vsphere.md
+++ b/docs/config-options/cloud-providers/vsphere/vsphere.md
@@ -6,7 +6,7 @@ This section describes how to enable the vSphere cloud provider. You will need t
 
 The [vSphere Cloud Provider](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/) interacts with VMware infrastructure (vCenter or standalone ESXi server) to provision and manage storage for persistent volumes in a Kubernetes cluster.
 
-When provisioning Kubernetes using RKE CLI or using [RKE clusters](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher) in Rancher, the vSphere Cloud Provider can be enabled by configuring the `cloud_provider` directive nested under the `rancher_kubernetes_engine_config` directive in the cluster config YAML file. For more information on the configuration file structure please see the [Rancher RKE Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#config-file-structure-in-rancher).
+When provisioning Kubernetes using RKE CLI or using [RKE clusters](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher) in Rancher, the vSphere Cloud Provider can be enabled by configuring the `cloud_provider` directive nested under the `rancher_kubernetes_engine_config` directive in the cluster config YAML file. For more information on the configuration file structure, please see the [Rancher RKE Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#config-file-structure-in-rancher).
 
 ### Related Links
 

--- a/docs/config-options/cloud-providers/vsphere/vsphere.md
+++ b/docs/config-options/cloud-providers/vsphere/vsphere.md
@@ -2,18 +2,9 @@
 title: vSphere Cloud Provider
 ---
 
-This section describes how to enable the vSphere cloud provider. You will need to use the `cloud_provider` directive in the cluster YAML file.
+This section describes how to enable the vSphere cloud provider. You will need to use the `cloud_provider` directive in the cluster YAML file. For more details on configuring the file structure refer to the [configuration reference](./config-reference/config-reference.md).
 
 The [vSphere Cloud Provider](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/) interacts with VMware infrastructure (vCenter or standalone ESXi server) to provision and manage storage for persistent volumes in a Kubernetes cluster.
-
-When provisioning Kubernetes using RKE CLI or using [RKE clusters](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher) in Rancher, the vSphere Cloud Provider can be enabled by configuring the `cloud_provider` directive nested under the `rancher_kubernetes_engine_config` directive in the cluster config YAML file. For more information on the configuration file structure, please see the [Rancher RKE Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#config-file-structure-in-rancher).
-
-### Related Links
-
-- **Configuration:** For details on vSphere configuration in RKE, refer to the [configuration reference.](./config-reference/config-reference.md)
-- **Troubleshooting:** For guidance on troubleshooting a cluster with the vSphere cloud provider enabled, refer to the [troubleshooting section.](./troubleshooting/troubleshooting.md)
-- **Storage:** If you are setting up storage, see the [official vSphere documentation on storage for Kubernetes,](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/) or the [official Kubernetes documentation on persistent volumes.](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) If you are using Rancher, refer to the [Rancher documentation on provisioning storage in vSphere.](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage#docusaurus_skipToContent_fallback)
-- **For Rancher users:** Refer to the Rancher documentation on [creating vSphere Kubernetes clusters](https://ranchermanager.docs.rancher.com/pages-for-subheaders/vsphere) and [provisioning storage.](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage#docusaurus_skipToContent_fallback)
 
 ## Prerequisites
 
@@ -23,4 +14,15 @@ When provisioning Kubernetes using RKE CLI or using [RKE clusters](https://ranch
 
 ## Enabling the vSphere Provider with the RKE CLI
 
-To enable the vSphere Cloud Provider in the cluster, you must add the top-level `cloud_provider` directive to the cluster configuration file, set the `name` property to `vsphere` and add the `vsphereCloudProvider` directive containing the configuration matching your infrastructure. See the [configuration reference](./config-reference/config-reference.md) for the gory details.
+To enable the vSphere Cloud Provider in the cluster, you must add the top-level `cloud_provider` directive to the cluster configuration file, set the `name` property to `vsphere` and add the `vsphereCloudProvider` directive containing the configuration matching your infrastructure. See the [configuration reference](./config-reference/config-reference.md) for more details.
+
+## Enabling the vSphere Provider in Rancher
+
+When provisioning Kubernetes using [RKE clusters](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher) in Rancher, the vSphere Cloud Provider can be enabled by configuring the `cloud_provider` directive nested under the `rancher_kubernetes_engine_config` directive in the cluster config YAML file. For more information on the configuration file structure please see the [Rancher RKE Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#config-file-structure-in-rancher).
+
+## Related Links
+
+- **Configuration:** For details on vSphere configuration in RKE, refer to the [configuration reference.](./config-reference/config-reference.md)
+- **Troubleshooting:** For guidance on troubleshooting a cluster with the vSphere cloud provider enabled, refer to the [troubleshooting section.](./troubleshooting/troubleshooting.md)
+- **Storage:** If you are setting up storage, see the [official vSphere documentation on storage for Kubernetes,](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/) or the [official Kubernetes documentation on persistent volumes.](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) If you are using Rancher, refer to the [Rancher documentation on provisioning storage in vSphere.](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage#docusaurus_skipToContent_fallback)
+- **For Rancher users:** Refer to the Rancher documentation on [creating vSphere Kubernetes clusters](https://ranchermanager.docs.rancher.com/pages-for-subheaders/vsphere) and [provisioning storage.](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/vsphere-storage#docusaurus_skipToContent_fallback)

--- a/docs/config-options/cloud-providers/vsphere/vsphere.md
+++ b/docs/config-options/cloud-providers/vsphere/vsphere.md
@@ -6,7 +6,7 @@ This section describes how to enable the vSphere cloud provider. You will need t
 
 The [vSphere Cloud Provider](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/) interacts with VMware infrastructure (vCenter or standalone ESXi server) to provision and manage storage for persistent volumes in a Kubernetes cluster.
 
-When provisioning Kubernetes using RKE CLI or using [RKE clusters](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher) in Rancher, the vSphere Cloud Provider can be enabled by configuring the `cloud_provider` directive in the cluster YAML file.
+When provisioning Kubernetes using RKE CLI or using [RKE clusters](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher) in Rancher, the vSphere Cloud Provider can be enabled by configuring the `cloud_provider` directive nested under the `rancher_kubernetes_engine_config` directive in the cluster config YAML file. For more information on the configuration file structure please see the [Rancher RKE Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#config-file-structure-in-rancher).
 
 ### Related Links
 


### PR DESCRIPTION
Updating the vSphere and OpenStack cloud provider pages with more information on the `rancher_kubernetes_engine_config` directive and where to update the cluster config YAML file.

Fixes https://github.com/rancher/rancher-docs/issues/140