### PR TITLE
Add back link check during test deploy workflow

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Check links
+        run: yarn run remark --quiet --use remark-validate-links --use remark-lint-no-dead-urls ./docs
       - name: Test build website
         run: yarn build
  


### PR DESCRIPTION
Inadvertently removed the link check when updating the test deploy workflow in #82. This adds it back.